### PR TITLE
compat: Allow Aqua 0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,16 @@ FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 
 [compat]
+Aqua = "0.6, 0.8"
 ColorTypes = "0.10, 0.11, 0.12"
 ColorVectorSpace = "0.9, 0.10, 0.11"
 FixedPointNumbers = "0.8"
+Glob = "1"
+ImageCore = "0.10"
 LRUCache = "1.2"
+Test = "1"
+TiffImages = "0.11"
+XMLDict = "0.4"
 julia = "1"
 
 [extras]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -8,4 +8,4 @@ TiffImages = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
-Aqua = "0.6"
+Aqua = "0.6, 0.8"


### PR DESCRIPTION
Aqua 0.6.x's type-piracy/ambiguity detection produces false positives under JuliaLang/julia#61915 (the TypeEq refactor): Type{T} is now a TypeEq kind, so the package's own inner constructors are mis-flagged as piracy. Aqua 0.8.15 fixes this. Allow Aqua 0.8 and add the [compat]/API adjustments required by Aqua 0.8 so the test suite passes on recent Julia.

This change was made with the assistance of generative AI (Claude Code).